### PR TITLE
fix(release): allow release plan push check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
     needs: [lint-maven, build-maven, test-maven, test-release, lint-reuse]
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     outputs:
       new-release-published: ${{ steps.semantic-release.outputs.new_release_published }}
       new-release-version: ${{ steps.semantic-release.outputs.new_release_version }}


### PR DESCRIPTION
Allows semantic-release dry-run to perform its required push-permission check. Fork validation follow-up.